### PR TITLE
Add Jest tests for scrollspy refresh function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
-#Interactive Portfolio
+# Interactive Portfolio
 My portfolio representing my profile as a web developer.
 Link : https://avnishpandey113.github.io/
+
+## Running Tests
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Run the test suite:
+   ```bash
+   npm test
+   ```

--- a/js/function.js
+++ b/js/function.js
@@ -1,3 +1,9 @@
-// $('[data-spy="scroll"]').each(function () {
-//   var $spy = $(this).scrollspy('refresh')
-// })
+function refreshScrollSpy() {
+  $('[data-spy="scroll"]').each(function () {
+    $(this).scrollspy('refresh');
+  });
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { refreshScrollSpy };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "avnishpandey113.github.io",
+  "version": "1.0.0",
+  "description": "My portfolio representing my profile as a web developer. Link : https://avnishpandey113.github.io/",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/function.test.js
+++ b/tests/function.test.js
@@ -1,0 +1,34 @@
+const { refreshScrollSpy } = require('../js/function');
+
+describe('refreshScrollSpy', () => {
+  test('calls scrollspy refresh for each spy element', () => {
+    document.body.innerHTML = `
+      <div data-spy="scroll"></div>
+      <div data-spy="scroll"></div>
+      <div data-spy="scroll"></div>
+    `;
+
+    const scrollspyMock = jest.fn();
+
+    global.$ = (selector) => {
+      if (typeof selector === 'string') {
+        const elements = Array.from(document.querySelectorAll(selector));
+        return {
+          each: (callback) => {
+            elements.forEach((el, idx) => {
+              callback.call(el, idx, el);
+            });
+          }
+        };
+      }
+      return { scrollspy: scrollspyMock };
+    };
+
+    refreshScrollSpy();
+
+    expect(scrollspyMock).toHaveBeenCalledTimes(3);
+    scrollspyMock.mock.calls.forEach((call) => {
+      expect(call[0]).toBe('refresh');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- export scrollspy refresh logic as `refreshScrollSpy`
- add Jest test verifying scrollspy refresh runs for each `[data-spy="scroll"]`
- document how to run the new test suite

## Testing
- `npm test` *(fails: jest not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6895258128fc8322b8884363a41f0905