### PR TITLE
fix: correct Bootstrap version comment

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
       href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700;800;900&display=swap"
       rel="stylesheet"
     />
-    <!-- bootstrap v4.5-->
+    <!-- bootstrap v4.3.1-->
     <link
       rel="stylesheet"
       href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"


### PR DESCRIPTION
## Summary
- Correct Bootstrap version comment to v4.3.1

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -L -o /tmp/bootstrap.css -w '%{http_code}\n' https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css` *(failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6895257f631c8322815f708c13ca2067